### PR TITLE
Fix modern metalint nits

### DIFF
--- a/U/modified/d_union_semun.U
+++ b/U/modified/d_union_semun.U
@@ -45,7 +45,7 @@
 ?H:#$d_semctl_semid_ds USE_SEMCTL_SEMID_DS	/**/
 ?H:.
 ?T:xxx also
-?F:!try
+?F:!try !tryh.h
 ?LINT: set d_union_semun d_semctl_semun d_semctl_semid_ds
 : see whether sys/sem.h defines union semun
 echo " "

--- a/U/perl/d_statfs3.U
+++ b/U/perl/d_statfs3.U
@@ -19,6 +19,7 @@
 ?C:.
 ?H:#$d_statfs3 HAS_STATFS3		/**/
 ?H:.
+?F: !try.h
 ?LINT:set d_statfs3
 : Check for statfs3
 case "$d_statfs" in
@@ -59,7 +60,7 @@ EOCP
 	case "$val" in
 	$define) echo "Yes, it can."  ;;
 	$undef)  echo "No, it can't." ;;
-	$rm_try
+	$rm_try try.h
 	esac
 	;;
 *)	val="$undef"

--- a/U/perl/d_statfs4.U
+++ b/U/perl/d_statfs4.U
@@ -19,6 +19,7 @@
 ?C:.
 ?H:#$d_statfs4 HAS_STATFS4		/**/
 ?H:.
+?F: !try.h
 ?LINT:set d_statfs4
 : Check for statfs4
 case "$d_statfs" in
@@ -60,7 +61,7 @@ EOCP
 	$define) echo "Yes, it can."  ;;
 	$undef)  echo "No, it can't." ;;
 	esac
-	$rm_try
+	$rm_try try.h
 	;;
 *)	val="$undef"
 	;;

--- a/U/perl/dtraceobject.U
+++ b/U/perl/dtraceobject.U
@@ -14,6 +14,7 @@
 ?S:	and dtrace -G with -xnolibs to allow dtrace to run in a jail on
 ?S:	FreeBSD.
 ?S:.
+?F: !perldtrace.h
 ?T:xnolibs
 : Probe whether dtrace builds an object, as newer Illumos requires an input
 : object file that uses at least one of the probes defined in the .d file


### PR DESCRIPTION
These are detected by metalint since SVN r132 /
 https://github.com/rmanfredi/dist/commit/8160f5523cbbb37197732ea645d02f884e180f3c

with
 "d_statfs3.U": unknown private file 'try.h'.
 "d_statfs4.U": unknown private file 'try.h'.
 "d_union_semun.U": unknown private file 'tryh.h'.
 "dtraceobject.U": unknown private file 'perldtrace.h'.

Even though $rm_try removes try.[cho] anyway, we clean try.h
explicitly to work around the resulting
 "U/perl/d_statfs4.U": unused temporary file 'try.h'.
warnings which seem like a bug in metalint.