### PR TITLE
Use Getopt::Std::getopts() as it comes with all Perl 5 versions.

### DIFF
--- a/bin/mconfig
+++ b/bin/mconfig
@@ -4,6 +4,7 @@ use sort "stable";
 BEGIN { $ENV{LC_ALL} = "C"; }
 
 use FindBin;
+use Getopt::Std;
 
 $p5_metaconfig_base = "$FindBin::Bin/../";
 chdir "$p5_metaconfig_base/perl" or
@@ -56,8 +57,7 @@ $patchlevel = '0';
 $grep = '/usr/bin/grep';
 chop($date = `date`);
 &profile;						# Read ~/.dist_profile
-require 'getopts.pl';
-&usage unless &Getopts("dhkmoOstvwGMVL:");
+&usage unless getopts("dhkmoOstvwGMVL:");
 
 $MC = $opt_L if $opt_L;			# May override public library path
 $MC = &tilda_expand($MC);		# ~name expansion

--- a/bin/mlint
+++ b/bin/mlint
@@ -3,6 +3,7 @@
 BEGIN { $ENV{LC_ALL} = "C"; }
 
 use FindBin;
+use Getopt::Std;
 
 $p5_metaconfig_base = "$FindBin::Bin/../";
 chdir "$p5_metaconfig_base/perl" ||
@@ -44,8 +45,7 @@ $version = '3.5';
 $patchlevel = '0';
 $grep = '/usr/bin/grep';
 &profile;						# Read ~/.dist_profile
-require 'getopts.pl';
-&usage unless &Getopts("hklVL:oOs");
+&usage unless getopts("hklVL:oOs");
 
 if ($opt_V) {
 	print STDERR "metalint $version PL$patchlevel\n";


### PR DESCRIPTION
Instead of Perl 4 getopts.pl.

For:  https://github.com/perl5-metaconfig/metaconfig/issues/14