### PR TITLE
Check that the necessary symlinks exist for mconfig and mlint

### DIFF
--- a/bin/mconfig
+++ b/bin/mconfig
@@ -12,6 +12,9 @@ chdir "$p5_metaconfig_base/perl" or
 -w 'Configure' && -w 'config_h.SH' or
     die "both Configure and config_h.SH must be writable\n";
 
+-l '.package' && -l 'U' or
+    die ".package and U should be symlinks as per README\n";
+
 # $Id: mconfig.SH 22 2008-05-28 08:01:59Z rmanfredi $
 #
 #  Copyright (c) 1991-1997, 2004-2006, Raphael Manfredi

--- a/bin/mlint
+++ b/bin/mlint
@@ -8,6 +8,9 @@ $p5_metaconfig_base = "$FindBin::Bin/../";
 chdir "$p5_metaconfig_base/perl" ||
     die "perl/ directory missing in $p5_metaconfig_base\n";
 
+-l '.package' && -l 'U' or
+    die ".package and U should be symlinks as per README\n";
+
 # $Id: mlint.SH 22 2008-05-28 08:01:59Z rmanfredi $
 #
 #  Copyright (c) 1991-1997, 2004-2006, Raphael Manfredi


### PR DESCRIPTION
The README suggests that MANIFEST.new should be a symlink to MANIFEST, but this doesn't seem to be strictly required (or even correct?) so I'm leaving it out of this check for now. MANIFEST.new ended up as a regular file at some point during my testing.