### PR TITLE
Fix pointer to integer cast in null_printf check

### DIFF
--- a/U/modified/d_attribut.U
+++ b/U/modified/d_attribut.U
@@ -159,8 +159,15 @@ $cat >attrib.c <<EOCP
 #ifdef I_STDLIB
 #include <stdlib.h>
 #endif
+#$i_inttypes I_INTTYPES
+#ifdef I_INTTYPES
+#include <inttypes.h>
+#endif
+#ifndef INTPTR_MAX
+#define intptr_t int
+#endif
 int null_printf (char* pat,...) __attribute__((__format__(__printf__,1,2)));
-int null_printf (char* pat,...) { return (int)pat; }
+int null_printf (char* pat,...) { return (int)(intptr_t)pat; }
 int main () { exit(null_printf(NULL)); }
 EOCP
 	if $cc $ccflags -o attrib attrib.c >attrib.out 2>&1 ; then


### PR DESCRIPTION
Quoting James Cowgill in https://bugs.debian.org/893601

> I recently noticed a build failure in the "mrs" package which embeds the
> perl interpreter. The strange part was that the error looked completely
> generic but only failed on 32-bit for some reason. I traced this to the
> value of the PRINTF_FORMAT_NULL_OK config,h option in perl which is
> defined on 32-bit, but not defined on 64-bit architectures. This is a
> bug because this check detects the behavior of the compiler and should
> be the same on all architectures with the same GCC version.
>
> The underlying bug is that the check for this warning causes GCC to emit
> an unrelated warning on 64-bit arches which tricks the check into not
> defining PRINTF_FORMAT_NULL_OK.
>
> The line which causes the warning is:
>  int null_printf (char* pat,...) { return (int)pat; }
>
> GCC complains about the pointer to integer cast of the wrong size but
> only on 64-bits. I've attached a patch to fix this by casting through
> intptr_t first.

Bug-Debian: https://bugs.debian.org/893601