### PR TITLE
Exclusions in package file

### DIFF
--- a/.package
+++ b/.package
@@ -1,4 +1,4 @@
-: This file was created by running packinit on ma 28 syys   17.56.27 1998.
+: This file was created by running packinit on Thu Apr 19 17:35:50 CEST 2018.
 : Do not hand edit -- run packinit again if changes are to be made.
 packver='3.036'
 : Basic variables
@@ -20,6 +20,8 @@ changercs=0
 : File lookup extensions
 cext='.xs'
 shext=''
+: File to consult for symbol exclusions
+exclusions_file='.metaconf-exclusions.txt'
 : Mailing list variables
 list_users='false'
 list_name=''
@@ -30,4 +32,3 @@ list_sub=''
 list_unsub=''
 : Derivative variables -- do not change
 revbranch="$baserev.$patchbranch"
-

--- a/README
+++ b/README
@@ -88,7 +88,7 @@ Development workflow:
 
     $ export MC5=/your/path/to/metaconfig
     $ alias ml="perl $MC5/bin/mlint -O"
-    $ alias mc="perl $MC5/bin/mconfig -m -O -X .metaconf-exclusions.txt"
+    $ alias mc="perl $MC5/bin/mconfig -m -O"
 
     examples in the rest of this README will just refer to mlint and mconfig
     as if they appear in your $PATH
@@ -144,8 +144,7 @@ Development workflow:
     string HAS_STRTOLD_L at the end of the comment.  This can be removed once
     the code base has actual uses of the unit.
 
-(f) "mconfig -m -O -X .metaconf-exclusions.txt" to regenerate Configure and
-    config_h.SH
+(f) "mconfig -m -O" to regenerate Configure and config_h.SH
 
     Make *sure* your mconfig is the correct one in your $PATH, as the mono-web
     package will install /usr/bin/mconfig which will do something completely

--- a/bin/mconfig
+++ b/bin/mconfig
@@ -60,7 +60,7 @@ chop($date = `date`);
 &usage unless getopts("dhkmoOstvwGMVL:X:");
 
 my %excluded_symbol;
-read_exclusions($opt_X) if defined $opt_X;
+read_exclusions($opt_X);
 $MC = $opt_L if $opt_L;			# May override public library path
 $MC = &tilda_expand($MC);		# ~name expansion
 chop($WD = `pwd`);				# Working directory
@@ -142,7 +142,7 @@ sub init_except {
 # Print out metaconfig's usage and exits
 sub usage {
 	print STDERR <<'EOH';
-Usage: metaconfig [-dhkmostvwGMV] [-L dir]
+Usage: metaconfig [-dhkmostvwGMV] [-L dir] [-X file]
   -d : debug mode.
   -h : print this help message and exits.
   -k : keep temporary directory.
@@ -156,7 +156,7 @@ Usage: metaconfig [-dhkmostvwGMV] [-L dir]
   -L : specify main units repository.
   -M : activate production of confmagic.h.
   -V : print version number and exits.
-  -X FILE : read symbol exclusions from FILE
+  -X : read symbol exclusions from file (overriding .package)
 EOH
 	exit 1;
 }
@@ -815,6 +815,10 @@ sub q {
 
 sub read_exclusions {
 	my ($filename) = @_;
+	if (!defined $filename) {
+		$filename = $exclusions_file; # default to name from .package
+		return if !defined $filename || $filename eq '';
+	}
 	print "Reading exclusions from $filename...\n" unless $opt_s;
 	open(EXCLUSIONS, "< $filename\0") || die "Can't read $filename: $!\n";
 	local $_;

--- a/bin/packinit
+++ b/bin/packinit
@@ -171,6 +171,19 @@ EOM
 $shext = &myread('Additional file extensions to identify SH files?', $dflt);
 $shext = '' if $shext eq 'none';
 
+$dflt = 'none';
+print <<'EOM';
+
+If your package sources contains symbols that metaconfig will mistake for the
+names of symbols defined by its units, you can list them in an exclusions file.
+(See the documentation of "metaconfig -X".) What file would you like metaconfig
+to consult for those symbols? Say "none" if you don't need to exclude any
+symbols.
+
+EOM
+$exclusions_file = &myread('File to consult for excluded symbols?', $dflt);
+$exclusions_file = '' if $exclusions_file eq 'none';
+
 $dflt = $copyright eq ' ' ? 'n' : 'y';
 print <<'EOM';
 
@@ -406,6 +419,8 @@ changercs=$changercs
 : File lookup extensions
 cext='$cext'
 shext='$shext'
+: File to consult for symbol exclusions
+exclusions_file='$exclusions_file'
 : Mailing list variables
 list_users='$list_users'
 list_name='$list_name'


### PR DESCRIPTION
This branch pulls in some of the later changes from rmanfredi/dist#14. Raphaël suggested that the `.package` file be permitted to name the file used for the `-X` option, and that `packinit` prompt for it. Those changes have now been applied to our local copy of the (generated) `bin/mconfig` file, and I've regenerated our `.package` file with the relevant setting. Finally, our README no longer recommends the option, as it's no longer needed.

