### PR TITLE
(perl #134360) --sysroot apparently needs the =

### DIFF
--- a/U/perl/dlsrc.U
+++ b/U/perl/dlsrc.U
@@ -279,7 +279,7 @@ EOM
 	if $test "X$sysroot" != X; then
 	    case "$gccversion" in
 		'') ;;
-		*)  dflt="$dflt --sysroot $sysroot" ;;
+		*)  dflt="$dflt --sysroot=$sysroot" ;;
 	    esac
 	fi
 


### PR DESCRIPTION
See: https://rt.perl.org/Ticket/Display.html?id=134360

6e404ab585deadc1c32d50513f13b50ae395c00d in perl.git

I wasn't able to test it, but the change is minimal and matches the gcc documentation.