### PR TITLE
c99 requires functions to be declared before they're called

### DIFF
--- a/U/perl/d_futimes.U
+++ b/U/perl/d_futimes.U
@@ -28,6 +28,7 @@ $cat >try.c <<EOCP
 #include <sys/time.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <stdlib.h>
 
 int main ()
 {


### PR DESCRIPTION
and exit() is declared in stdlib.h

based on https://rt.perl.org/Ticket/Display.html?id=134432